### PR TITLE
hpack 4.1.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
   sha256: ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca
 
 build:
+  skip: true  # [py<39]
   number: 0
-  noarch: python
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  #sha256: ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca
   url: https://github.com/python-hyper/hpack/archive/refs/tags/v4.1.0.tar.gz
   sha256: d8e08ec703362fab42224f31e3eee0a73b8c6a28e1f05c1318feb2c54453abcf
 
@@ -41,12 +39,19 @@ test:
     - pytest -vv tests
 
 about:
-  home: http://python-hyper.org/hpack/
+  home: https://python-hyper.org/projects/hpack
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: HTTP/2 Header Encoding for Python
+  description: |
+    hpack provides a simple Python interface to the HPACK compression algorithm, 
+    used to compress HTTP headers in HTTP/2. Used by some of the most popular
+    HTTP/2 implementations in Python, HPACK offers a great Python interface as
+    well as optional upgrade to optimised C-based compression routines from
+    nghttp2.
   dev_url: https://github.com/python-hyper/hpack
+  doc_url: https://python-hyper.org/projects/hpack
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<39]
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "hpack" %}
-{% set version = "4.0.0" %}
-{% set sha256 = "fc41de0c63e687ebffde81187a948221294896f6bdc0ae2312708df339430095" %}
+{% set version = "4.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,9 +18,9 @@ build:
 requirements:
   host:
     - python
-    - setuptools
     - pip
-    - wheel
+    - setuptools
+    - wheel >=0.45.0,<1
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,10 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca
+  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  #sha256: ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca
+  url: https://github.com/python-hyper/hpack/archive/refs/tags/v4.1.0.tar.gz
+  sha256: d8e08ec703362fab42224f31e3eee0a73b8c6a28e1f05c1318feb2c54453abcf
 
 build:
   skip: true  # [py<39]
@@ -26,6 +28,17 @@ requirements:
 test:
   imports:
     - hpack
+  source_files:
+    - tests
+  requires:
+    - python
+    - pip
+    - pytest >=8.3.3,<9
+    - hypothesis >=6.119.4,<7
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -vv tests
 
 about:
   home: http://python-hyper.org/hpack/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/python-hyper/hpack/archive/refs/tags/v4.1.0.tar.gz
+  url: https://github.com/python-hyper/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: d8e08ec703362fab42224f31e3eee0a73b8c6a28e1f05c1318feb2c54453abcf
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca
 


### PR DESCRIPTION
hpack 4.1.0 

**Destination channel:** Defaults

### Links

- [PKG-8964]
- dev_url:        https://github.com/python-hyper/hpack/tree/v4.1.0
- conda_forge:    https://github.com/conda-forge/hpack-feedstock
- pypi:           https://pypi.org/project/hpack/4.1.0
- pypi inspector: https://inspector.pypi.io/project/hpack/4.1.0

### Explanation of changes:

- new version number


[PKG-8964]: https://anaconda.atlassian.net/browse/PKG-8964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ